### PR TITLE
update ignoredImages from marathon deploys and remove google code dep.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_ROOT = ./bin
 
 test:
-	go test ./... -v -cover 
+	go test ./... -v -cover
 
 build:
 	go build -o $(BUILD_ROOT)/notadash \
@@ -22,7 +22,7 @@ build-deps:
 	go get github.com/marpaia/graphite-golang
 	go get github.com/codegangsta/cli
 	go get github.com/ryanuber/columnize
-	go get code.google.com/p/gcfg
+	go get github.com/scalingdata/gcfg
 	go get github.com/fsouza/go-dockerclient
 	go get github.com/gambol99/go-marathon
 	go get github.com/boldfield/go-mesos

--- a/lib/config.go
+++ b/lib/config.go
@@ -1,7 +1,7 @@
 package lib
 
 import (
-	"code.google.com/p/gcfg"
+	"github.com/scalingdata/gcfg"
 	"log"
 )
 


### PR DESCRIPTION
This creates the ignoredImages during the initial marathon matrix creation and continues to append to it during the chronos checks. "tested" by triggering a deploy in staging and running `notadash-mon slave` on one of the hosts with an active deploy.

Also, moved gcfg to github fork due to: 

```[notadash] make build-deps
go get github.com/marpaia/graphite-golang
go get github.com/codegangsta/cli
go get github.com/ryanuber/columnize
go get code.google.com/p/gcfg
package code.google.com/p/gcfg: unable to detect version control system for code.google.com/ path
Makefile:21: recipe for target 'build-deps' failed```

per: https://github.com/tools/godep/issues/221

